### PR TITLE
When authenticating also return the identity URL 

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -487,7 +487,8 @@ Connection.prototype.authorize = function(code, callback) {
     var userId = idUrls.pop(), orgId = idUrls.pop();
     var userInfo = {
       id: userId,
-      organizationId: orgId
+      organizationId: orgId,
+      url: res.id
     };
     self.initialize({
       instanceUrl : res.instance_url,
@@ -530,7 +531,8 @@ Connection.prototype.loginByOAuth2 = function(username, password, callback) {
     var userId = idUrls.pop(), orgId = idUrls.pop();
     var userInfo = {
       id: userId,
-      organizationId: orgId
+      organizationId: orgId,
+      url: id
     };
     self.initialize({
       instanceUrl : res.instance_url,

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -19,6 +19,7 @@ vows.describe("connection").addBatch({
       assert.isString(conn.accessToken);
       assert.isString(userInfo.id);
       assert.isString(userInfo.organizationId);
+      assert.isString(userInfo.url);
     }
   }
 
@@ -327,6 +328,7 @@ vows.describe("connection").addBatch({
     "done" : function(userInfo) {
       assert.isString(userInfo.id);
       assert.isString(userInfo.organizationId);
+      assert.isString(userInfo.url);
       assert.isString(conn.accessToken);
       assert.isString(conn.refreshToken);
     },


### PR DESCRIPTION
as it is sometimes easier to get the URL directly instead of the orgId and userId 
