### PR TITLE
added support for updated and deleted sobject endpoints

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -311,6 +311,24 @@ function parseCSV(str) {
 /** @private */
 function parseText(str) { return str; }
 
+/** @private */
+function formatDate(date) {
+  function pad(number) {
+    if (number < 10) {
+      return '0' + number;
+    }
+    return number;
+  }
+
+  return date.getUTCFullYear() +
+    '-' + pad(date.getUTCMonth() + 1) +
+    '-' + pad(date.getUTCDate()) +
+    'T' + pad(date.getUTCHours()) +
+    ':' + pad(date.getUTCMinutes()) +
+    ':' + pad(date.getUTCSeconds()) +
+    '+00:00';
+}
+
 /**
  * Refresh access token
  * @private
@@ -962,5 +980,89 @@ Connection.prototype.logout = function(callback) {
     // nothing useful returned by logout API, just return
     return undefined;
 
+  }).thenCall(callback);
+};
+
+/**
+ * Retrieve updated records
+ *
+ * @param {String} type - SObject Type
+ * @param {String|Date} start - start date or string representing the start of the interval
+ * @param {String|Date} end - start date or string representing the end of the interval must be > start
+ * @param {Callback.<Object>} [callback] - Callback function
+ * @returns {Promise.<Object>}
+ */
+Connection.prototype.updated = function (type, start, end, callback) {
+  var url = [ this._baseUrl(), "sobjects", type, "updated" ].join('/');
+
+  if (typeof start === 'string') {
+    start = new Date(start);
+  }
+
+  if (start instanceof Date) {
+    start = formatDate(start);
+  }
+
+  if (start) {
+    url += "?start=" + encodeURIComponent(start);
+  }
+
+  if (typeof end === 'string') {
+    end = new Date(end);
+  }
+
+  if (end instanceof Date) {
+    end = formatDate(end);
+  }
+
+  if (end) {
+    url += "&end=" + encodeURIComponent(end);
+  }
+
+  return this._request({
+    method: 'GET',
+    url: url
+  }).thenCall(callback);
+};
+
+/**
+ * Retrieve deleted records
+ *
+ * @param {String} type - SObject Type
+ * @param {String|Date} start - start date or string representing the start of the interval
+ * @param {String|Date} end - start date or string representing the end of the interval
+ * @param {Callback.<Object>} [callback] - Callback function
+ * @returns {Promise.<Object>}
+ */
+Connection.prototype.deleted = function (type, start, end, callback) {
+  var url = [ this._baseUrl(), "sobjects", type, "deleted" ].join('/');
+
+  if (typeof start === 'string') {
+    start = new Date(start);
+  }
+
+  if (start instanceof Date) {
+    start = formatDate(start);
+  }
+
+  if (start) {
+    url += "?start=" + encodeURIComponent(start);
+  }
+
+  if (typeof end === 'string') {
+    end = new Date(end);
+  }
+
+  if (end instanceof Date) {
+    end = formatDate(end);
+  }
+
+  if (end) {
+    url += "&end=" + encodeURIComponent(end);
+  }
+
+  return this._request({
+    method: 'GET',
+    url: url
   }).thenCall(callback);
 };

--- a/lib/sobject.js
+++ b/lib/sobject.js
@@ -339,3 +339,27 @@ SObject.prototype.deleteHardBulk =
 SObject.prototype.destroyHardBulk = function(input, callback) {
   return this.bulkload("hardDelete", input, callback);
 };
+
+/**
+ * Retrieve the updated records
+ *
+ * @param {String|Date} start - start date or string representing the start of the interval
+ * @param {String|Date} end - start date or string representing the end of the interval, must be > start
+ * @param {Callback.<Object>} [callback] - Callback function
+ * @returns {Promise.<Object>}
+ */
+SObject.prototype.updated = function (start, end, callback) {
+  return this._conn.updated(this.type, start, end, callback);
+};
+
+/**
+ * Retrieve the deleted records
+ *
+ * @param {String|Date} start - start date or string representing the start of the interval
+ * @param {String|Date} end - start date or string representing the end of the interval, must be > start
+ * @param {Callback.<Object>} [callback] - Callback function
+ * @returns {Promise.<Object>}
+ */
+SObject.prototype.deleted = function (start, end, callback) {
+  return this._conn.deleted(this.type, start, end, callback);
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "database.com"
   ],
   "homepage": "http://github.com/stomita/node-salesforce",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/stomita/node-salesforce.git"

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -311,6 +311,106 @@ describe("connection", function() {
     });
   });
 
+  /**
+   *
+   */
+  describe("get updated account", function () {
+    it("should update successfully", function (done) {
+      conn.sobject('Account').record(account.Id).update({ Name: "Hello2" }, function (err, ret) {
+        if (err) { throw err; }
+        assert.ok(ret.success);
+      }.check(done));
+    });
+
+    describe("then get updated accounts", function () {
+      it("should return updated account object", function (done) {
+        var start = Date.now();
+        var end = Date.now();
+        var newDate = start.getDate() > 2 ? (start.getDate() - 2) : 0;
+        start.setDate(newDate);
+        conn.sobject('Account').updated(start, end, function (err, result) {
+          if (err) { throw err; }
+          assert.ok(_.isArray(result.ids));
+        }.check(done));
+      });
+    });
+  });
+
+  /**
+   *
+   */
+  describe("get updated account with string input", function () {
+    it("should update successfully", function (done) {
+      conn.sobject('Account').record(account.Id).update({ Name: "Hello2" }, function (err, ret) {
+        if (err) { throw err; }
+        assert.ok(ret.success);
+      }.check(done));
+    });
+
+    describe("then get updated accounts", function () {
+      it("should return updated account object", function (done) {
+        var start = Date.now();
+        var end = Date.now();
+        var newDate = start.getDate() > 2 ? (start.getDate() - 2) : 0;
+        start.setDate(newDate);
+        conn.sobject('Account').updated(start.toString(), end.toString(), function (err, result) {
+          if (err) { throw err; }
+          assert.ok(_.isArray(result.ids));
+        }.check(done));
+      });
+    });
+  });
+
+  /**
+   *
+   */
+  describe("get deleted account", function () {
+    it("should delete successfully", function (done) {
+      conn.sobject('Account').record(account.Id).destroy(function (err, ret) {
+        if (err) { throw err; }
+        assert.ok(ret.success);
+      }.check(done));
+    });
+
+    describe("then get deleted accounts", function () {
+      it("should return deleted account object", function (done) {
+        var start = Date.now();
+        var end = Date.now();
+        var newDate = start.getDate() > 2 ? (start.getDate() - 2) : 0;
+        start.setDate(newDate);
+        conn.sobject('Account').deleted(start, end, function (err, result) {
+          if (err) { throw err; }
+          assert.ok(_.isArray(result.deletedRecords));
+        }.check(done));
+      });
+    });
+  });
+
+  /**
+   *
+   */
+  describe("get deleted account with string input", function () {
+    it("should delete successfully", function (done) {
+      conn.sobject('Account').record(account.Id).destroy(function (err, ret) {
+        if (err) { throw err; }
+        assert.ok(ret.success);
+      }.check(done));
+    });
+
+    describe("then get deleted accounts", function () {
+      it("should return deleted account object", function (done) {
+        var start = Date.now();
+        var end = Date.now();
+        var newDate = start.getDate() > 2 ? (start.getDate() - 2) : 0;
+        start.setDate(newDate);
+        conn.sobject('Account').deleted(start.toString(), end.toString(), function (err, result) {
+          if (err) { throw err; }
+          assert.ok(_.isArray(result.deletedRecords));
+        }.check(done));
+      });
+    });
+  });
+
 
   /**
    *


### PR DESCRIPTION
Hello,

We found a need for the `updated` and `deleted` `SObject` endpoints so thought we would add them to this library. 
The API is documented in http://www.salesforce.com/us/developer/docs/api_rest/ under `REST API Reference / SObject Get Deleted` and `SObject Get Updated`. Example usages:
http://www.salesforce.com/us/developer/docs/api_rest/Content/dome_get_deleted.htm
http://www.salesforce.com/us/developer/docs/api_rest/Content/dome_get_updated.htm

I have added tests in the `connection.test.js` however I could not get the test suite to run properly. I could not get the tests to auth with Salesforce. I did create the `oauth` and `salesforce` `config` files. Also note that there is lag between updating or deleting sobject records and the actions being picked up and processed by internal Salesforce workers / queues and returned by the respective REST API. This is documented in the reference as well. That is why I do not test the actual content if the returned objects (ie check against the id's), just that the call worked and the basic structure of the result is correct.

I have tested inside my app with actual usage with good results.

Please review and provide feedback.

Thanks,

Bojan
